### PR TITLE
added kCFCoreFoundationVersionNumber_iOS_7_0

### DIFF
--- a/src/NimbusKitBasics.h
+++ b/src/NimbusKitBasics.h
@@ -316,6 +316,10 @@ CG_INLINE BOOL NIDeviceOSVersionIsAtLeast(double versionNumber) {
 #define kCFCoreFoundationVersionNumber_iOS_6_1 793.00
 #endif
 
+#ifndef kCFCoreFoundationVersionNumber_iOS_7_0
+#define kCFCoreFoundationVersionNumber_iOS_7_0 847.2
+#endif
+
 
 #pragma mark 32/64 Bit Support
 


### PR DESCRIPTION
see http://iphonedevwiki.net/index.php/Updating_extensions_for_iOS_7. the constant version number was known for awhile now
